### PR TITLE
Add user creation support in Admin dashboard

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -6,6 +6,7 @@ import {
   AuditLog,
   PageResponse,
   DashboardStats,
+  CreateUserRequest,
 } from '../types';
 
 export const adminApi = {
@@ -22,6 +23,11 @@ export const adminApi = {
 
   getUserById: async (id: number): Promise<User> => {
     const response = await apiClient.get<User>(`/admin/users/${id}`);
+    return response.data;
+  },
+
+  createUser: async (data: CreateUserRequest): Promise<User> => {
+    const response = await apiClient.post<User>('/admin/users', data);
     return response.data;
   },
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -27,6 +27,13 @@ export interface RegisterRequest {
   role: 'AGENT' | 'ADMIN';
 }
 
+export interface CreateUserRequest {
+  name: string;
+  email: string;
+  password: string;
+  role: 'AGENT' | 'ADMIN';
+}
+
 export interface ForgotPasswordRequest {
   email: string;
 }


### PR DESCRIPTION
## Summary
- Adds an "Add User" button to the Admin > User Management page
- Opens a form dialog with fields for name, email, password, and role (Agent/Admin)
- Wires up the existing `POST /api/admin/users` backend endpoint via a new `createUser` API method
- Includes client-side validation (required fields, email format, password min length)
- Auto-refreshes the user list on successful creation

## Changes
- `frontend/src/types/index.ts` - Added `CreateUserRequest` interface
- `frontend/src/api/admin.ts` - Added `createUser()` API method
- `frontend/src/pages/admin/UserManagement.tsx` - Added "Add User" button, create dialog with form, and create mutation

## Test plan
- [ ] Log in as admin (admin@insurance.com / Admin@123)
- [ ] Navigate to Admin > User Management
- [ ] Verify "Add User" button is visible
- [ ] Click "Add User" and verify the dialog opens with empty fields
- [ ] Submit with empty fields and verify validation errors appear
- [ ] Fill in valid data and submit — verify new user appears in the table
- [ ] Verify duplicate email is rejected with an error message

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)