### PR TITLE
Add factory profile.json for insurance-app-base

### DIFF
--- a/.factory/profile.json
+++ b/.factory/profile.json
@@ -1,0 +1,64 @@
+{
+  "_doc": "Factory profile for insurance-app-base — Insurance Agent Outreach + Voice AI Prospectus App. Facts only, kept current with the repo. See templates/profile.schema.json in claude-software-factory for field docs.",
+  "repo": "insurance-app-base",
+  "estate_role": "Standalone full-stack monorepo (Java/Spring Boot backend + React/Vite frontend in one repo, one deploy unit). No sibling repos in this estate; all epics are filed here.",
+  "stack": "Backend: Java 21, Spring Boot 3.2.2, Spring Security (JWT), Spring Data JPA, Spring AI (OpenAI chat/embeddings), pgvector, Flyway, Lombok + MapStruct, Maven. Frontend: React 18, TypeScript, Vite, Material-UI, TanStack Query, Zustand, react-hook-form, Vitest. Database: PostgreSQL 16 + pgvector. Infra: Docker + Docker Compose, GitHub Actions.",
+  "branches": {
+    "default": "main",
+    "staging": null
+  },
+  "commands": {
+    "test": "cd backend && mvn -B test && cd ../frontend && npm ci && npx vitest run --passWithNoTests",
+    "build": "cd backend && mvn -B clean package -DskipTests && cd ../frontend && npm ci && npm run build",
+    "lint": "cd frontend && npm ci && npm run lint"
+  },
+  "conventions": [
+    "Backend is modular by domain under backend/src/main/java/com/insurance/{module}: controller/ (REST endpoints), dto/ (request/response records, never expose entities), service/ (business logic), repository/ (Spring Data JPA), plus mapper/ (MapStruct) and exception/ where the module needs them",
+    "Shared JPA entities live only in common/entity/ — do not add entity classes inside a feature module",
+    "Admin-only endpoints are annotated @PreAuthorize(\"hasRole('ADMIN')\"); agent-scoped endpoints must filter by the authenticated agent so agents only ever see leads assigned to them (enforced in both repository queries and controllers)",
+    "New DB schema changes are a new Flyway migration at backend/src/main/resources/db/migration/V{next}__{description}.sql — never edit a already-applied migration; current head is V12",
+    "DTOs use Lombok (@Data/@Builder etc.) and MapStruct mappers for entity<->DTO conversion, following the pattern in leads/mapper/",
+    "Frontend pages live under frontend/src/pages/agent/ or frontend/src/pages/admin/; each new page gets an Axios client in frontend/src/api/, a route in App.tsx, and a Sidebar.tsx entry if it needs nav",
+    "Frontend server state goes through TanStack Query hooks in api/ clients; local/global UI state (auth) goes through the Zustand store in store/, not ad hoc context",
+    "Frontend types in frontend/src/types/ must mirror the backend DTOs they consume",
+    "Sensitive settings (API keys, credentials) are stored encrypted via the admin/ module's settings mechanism — never hard-coded or placed in plain application.yml"
+  ],
+  "review_checklist": [
+    "New/changed endpoints declare the correct @PreAuthorize (or are explicitly and intentionally open) — no permissive default",
+    "Agent-facing lead/product queries are scoped to the authenticated agent; only ADMIN-role code paths can see all leads",
+    "Any new table/column ships with a new, forward-only V{n}__ Flyway migration (never a rewrite of an existing one)",
+    "Entities from common/entity/ are never returned directly from controllers — DTOs only",
+    "No secrets or API keys committed in code, migrations, or docker-compose defaults",
+    "RAG/document flows that build prompts must still cite product IDs (anti-hallucination requirement) rather than freeform text",
+    "New frontend pages register a route in App.tsx and, if agent/admin-navigable, a Sidebar.tsx entry"
+  ],
+  "qa_notes": [
+    "Backend currently has zero test classes (no backend/src/test tree) — `mvn test` passes trivially; adding real tests is in scope whenever a task changes behavior a test could cover",
+    "Frontend currently has zero *.test.tsx/*.test.ts files — Vitest is configured but unused; run with --passWithNoTests until real specs exist, and add colocated *.test.tsx files with Vitest + React Testing Library patterns for new components",
+    "Voice AI flows should be exercised with VOICE_MOCK_MODE=true (mock mode avoids real OpenAI Realtime/Twilio calls and cost)",
+    "RAG/pgvector behavior needs a running Postgres with the vector extension — cannot be unit-tested without a database; prefer service-layer tests with the repository mocked where possible"
+  ],
+  "gotchas": [
+    "Local `mvn compile`/`mvn test` can fail on Lombok + OpenJDK 21.0.5 Temurin specifically (see KNOWN_ISSUES.md) with `TypeTag :: UNKNOWN` — this is an environment issue, not a code defect; if CI/agent JDK hits it, treat pre-existing failures with the same signature as environmental, not attributable to the current delta",
+    "Docker build (`docker-compose build backend`) is the known-working path when local Maven has the Lombok/JDK issue",
+    "There is no staging branch and no CI workflow (ci.yml) in this repo today — only claude.yml / claude-code-review.yml exist under .github/workflows; do not assume a staging deploy step exists",
+    "Default seed credentials (admin@insurance.com / Admin@123, agent@insurance.com / Agent@123) are dev-only seed data from V10__seed_initial_data.sql/V11 — never reuse these values as if they were secrets to protect, but never ship them into a real deployment's env either",
+    "swagger-ui is disabled by default (`springdoc.swagger-ui.enabled=true` must be set) — don't rely on it being reachable without checking application.yml"
+  ],
+  "reuse_hotspots": [
+    "backend/src/main/java/com/insurance/common/entity",
+    "backend/src/main/java/com/insurance/rag",
+    "frontend/src/api",
+    "frontend/src/components",
+    "frontend/src/utils"
+  ],
+  "deploy": {
+    "health_checks": [
+      "curl -fsS http://localhost:8080/actuator/health"
+    ],
+    "notes": [
+      "Flyway runs automatically on backend startup; a red health check after a merge that touched db/migration/ likely means a migration failed to apply — halt and check backend logs before promoting",
+      "backend healthcheck in docker-compose polls /actuator/health with a 60s start_period — a container reported unhealthy before that window elapses is not yet a real failure"
+    ]
+  }
+}


### PR DESCRIPTION
Authors the .factory/profile.json required by the claude-software-factory pipeline: stack facts, branch policy, test/build/lint commands, coding conventions, review checklist, QA notes, known gotchas (Lombok/JDK 21.0.5, no staging branch/CI yet), reuse hotspots, and deploy health checks. Validated against templates/profile.schema.json.