### PR TITLE
Add claude-software-factory workflows and config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "_doc": [
+    "Drop this at .claude/settings.json in a consuming repo (merge if one exists).",
+    "The permissions block CANNOT ship in the plugin — plugin settings.json supports",
+    "only `agent` and `subagentStatusLine`. It is half of the gate-G3 enforcement:",
+    "the hook blocks pushes, this deny list blocks merges. It must live here.",
+    "The two plugin keys declare the marketplace and record that the factory should",
+    "be enabled. They are NOT sufficient on their own — each machine still needs a",
+    "one-time `claude plugin install factory@genai-jerry` (verified: with only these",
+    "keys present and no prior install, /factory:* commands do not load).",
+    "Remove this _doc key before committing if you prefer."
+  ],
+  "permissions": {
+    "deny": [
+      "mcp__github__merge_pull_request",
+      "mcp__github__enable_pr_auto_merge"
+    ]
+  },
+  "extraKnownMarketplaces": {
+    "genai-jerry": {
+      "source": {
+        "source": "github",
+        "repo": "genai-jerry/claude-software-factory"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "factory@genai-jerry": true
+  }
+}

--- a/.github/factory-approvers.json
+++ b/.github/factory-approvers.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Gate -> GitHub usernames. spec = G1 approval; design = G2 approval; implementation = who is notified when tasks become factory:ready and may start implementers; release = G3 production go. Empty list = any owner/member/collaborator may approve that gate.",
+  "spec": ["genai-jerry"],
+  "design": ["genai-jerry"],
+  "implementation": ["genai-jerry"],
+  "release": ["genai-jerry"]
+}

--- a/.github/factory-models.json
+++ b/.github/factory-models.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Model preference chain per factory stage: the workflow probes each model in order and uses the first one the repo's credential can access. Missing roles fall back to claude-sonnet-5. Edit and merge to retune.",
+  "intake": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"],
+  "planner": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"],
+  "architect": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"],
+  "reviewer": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"],
+  "implementer": ["claude-opus-5", "claude-sonnet-5"],
+  "qa": ["claude-opus-5", "claude-sonnet-5"],
+  "release": ["claude-opus-5", "claude-sonnet-5"],
+  "dispatch": ["claude-haiku-4-5-20251001", "claude-sonnet-5"],
+  "ops": ["claude-haiku-4-5-20251001", "claude-sonnet-5"]
+}

--- a/.github/factory-test-request.json
+++ b/.github/factory-test-request.json
@@ -1,0 +1,6 @@
+{
+  "_doc": "Pilot-only trigger for the factory test harness. Edit role/issue on the development branch and push; the harness runs that role once. Set role back to \"none\" afterwards. Bump `attempt` to re-run the same role+issue (the push must change the file). Delete this file with the harness stub once the factory is live on the default branch.",
+  "role": "none",
+  "issue": "0",
+  "attempt": 1
+}

--- a/.github/workflows/factory-branch-guard.yml
+++ b/.github/workflows/factory-branch-guard.yml
@@ -1,0 +1,17 @@
+name: Factory branch guard
+
+# Caller stub. Flags commits that land on a protected branch without a PR.
+
+on:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  guard:
+    uses: genai-jerry/claude-software-factory/.github/workflows/factory-branch-guard.yml@v1
+    secrets: inherit

--- a/.github/workflows/factory-pipeline.yml
+++ b/.github/workflows/factory-pipeline.yml
@@ -1,0 +1,38 @@
+name: Factory pipeline
+
+# Caller stub. All logic lives in the factory repo; this file owns only the
+# triggers and the version pin. Bump both refs together when upgrading.
+
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue (or PR) number to run the role against"
+        required: true
+      role:
+        description: "Factory role to run"
+        required: true
+        type: choice
+        options: [intake, planner, architect, dispatch, implementer, reviewer, qa, release, ops]
+
+concurrency:
+  group: factory-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  factory:
+    uses: genai-jerry/claude-software-factory/.github/workflows/factory-pipeline.yml@v1
+    secrets: inherit
+    with:
+      role: ${{ inputs.role }}
+      issue_number: ${{ inputs.issue_number }}
+      factory_ref: v1

--- a/.github/workflows/factory-test.yml
+++ b/.github/workflows/factory-test.yml
@@ -1,0 +1,31 @@
+name: Factory test harness
+
+# Caller stub — PILOT ONLY. Lets you exercise factory roles from Actions before
+# the pipeline stub is merged to the default branch. Points at this repo's
+# factory development branch (claude/factory-workflows-files-mue4g9); delete
+# this file once the factory is live on the default branch.
+#
+# To run a stage: edit .github/factory-test-request.json on the dev branch and
+# push. Set "role" back to "none" afterwards.
+
+on:
+  push:
+    branches: [claude/factory-workflows-files-mue4g9]
+    paths: [".github/factory-test-request.json"]
+
+concurrency:
+  group: factory-test
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  harness:
+    uses: genai-jerry/claude-software-factory/.github/workflows/factory-test.yml@v1
+    secrets: inherit
+    with:
+      dev_branch: claude/factory-workflows-files-mue4g9
+      factory_ref: v1


### PR DESCRIPTION
Installs the consuming-repo footprint from genai-jerry/claude-software-factory (FACTORY.md §10): pipeline and branch-guard caller stubs, the pilot test harness pointed at this dev branch, per-repo model routing, gate approvers, and the .claude/settings.json permission deny list that enforces gate G3.


Claude-Session: https://claude.ai/code/session_018i6wV7cZb6kiKojzfaRZhj