### PR TITLE
Add factory-requirement GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/factory-requirement.yml
+++ b/.github/ISSUE_TEMPLATE/factory-requirement.yml
@@ -1,0 +1,58 @@
+name: "Factory requirement"
+description: "File a requirement for the software factory pipeline (agents will analyse, plan, design, implement, test and ship it)"
+title: "[Req] "
+labels: ["factory:intake"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue enters the **Software Factory** (see FACTORY.md in
+        claude-software-factory). Describe the *problem and outcome*, not the
+        solution — the Intake Analyst will turn this into a structured spec
+        for your approval (gate G1).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / need
+      description: What is broken, missing, or slow today? Who is affected?
+      placeholder: "Sales agents can't see which leads have unpaid follow-ups, so..."
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What should be true once this ships? Measurable if possible.
+      placeholder: "A rep opens a lead and immediately sees outstanding payment status..."
+    validations:
+      required: true
+  - type: checkboxes
+    id: repos
+    attributes:
+      label: Affected surface (best guess — the Intake Analyst will verify)
+      description: >-
+        insurance-app-base is a standalone full-stack monorepo with no
+        sibling repos in this estate — all epics are filed here.
+      options:
+        - label: Backend (Java/Spring Boot — backend/src/main/java/com/insurance/)
+        - label: Frontend (React/Vite — frontend/src/)
+        - label: Database (Flyway migrations — backend/src/main/resources/db/migration/)
+        - label: Infra / CI (Docker, docker-compose, GitHub Actions)
+        - label: Docs (README.md, CLAUDE.md, API_ENDPOINTS.md, etc.)
+        - label: Not sure
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints & context (optional)
+      description: Deadlines, compliance concerns, related issues, links to docs or screenshots.
+  - type: dropdown
+    id: size
+    attributes:
+      label: Rough size feeling
+      options:
+        - Small fix (consider factory:fast-track instead)
+        - Feature (single repo)
+        - Feature (multiple repos)
+        - Not sure
+    validations:
+      required: true


### PR DESCRIPTION
Copies templates/ISSUE_TEMPLATE/factory-requirement.yml from claude-software-factory into .github/ISSUE_TEMPLATE/, adapted for this repo's single-repo estate (per FACTORY.md §9 one-time setup): the "Affected repositories" checkboxes are replaced with the actual surfaces of this standalone monorepo (backend, frontend, database migrations, infra/CI, docs) instead of sibling-repo placeholders.