### PR TITLE
Add id-token write permission to factory pipeline workflow

### DIFF
--- a/.github/workflows/factory-pipeline.yml
+++ b/.github/workflows/factory-pipeline.yml
@@ -27,6 +27,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   factory:


### PR DESCRIPTION
## Summary
Updates the GitHub Actions factory pipeline workflow to include the `id-token: write` permission, enabling OIDC token generation for secure authentication with external services.

## Changes
- Added `id-token: write` permission to the workflow permissions block in `.github/workflows/factory-pipeline.yml`

## Details
This permission allows the workflow to generate OpenID Connect (OIDC) tokens, which can be used for keyless authentication with cloud providers and other services that support OIDC. This is a security best practice that eliminates the need to store long-lived credentials as secrets.

https://claude.ai/code/session_01A672jZA7YBW68AJiddxiQM