### PR TITLE
Document the factory intake flow in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,9 +236,12 @@ Agent: agent@insurance.com / Agent@123
 ```
 
 ### CI/CD Workflows
-- **ci.yml**: Build/test on PRs (backend tests, frontend build, Docker build)
-- **cd.yml**: Push images to GHCR on main branch
-- **deploy.yml**: SSH deploy to VM with docker-compose
+This repo consumes the [Claude Software Factory](https://github.com/genai-jerry/claude-software-factory) — an agentic pipeline (intake → plan → design → implement → review → QA → release) that turns a filed requirement into a shipped, reviewed PR.
+- **factory-pipeline.yml**: caller stub that runs the factory roles (intake, planner, architect, dispatch, implementer, reviewer, qa, release, ops) against an issue as it moves through `factory:*` labels
+- **factory-branch-guard.yml**: flags commits pushed directly to `main`/`master` without a PR
+- **factory-test.yml**: pilot-only harness for exercising factory roles from Actions; not part of the normal flow
+
+**Requesting work:** open an issue with the **Factory requirement** template (`.github/ISSUE_TEMPLATE/factory-requirement.yml`) — describe the problem/outcome, not the solution. This applies the `factory:intake` label and kicks off `factory-pipeline.yml`. See `FACTORY.md` in the claude-software-factory repo for the full pipeline and gate details.
 
 ### Common Development Tasks
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,15 @@ Once running, access interactive API documentation:
 
 ## 🤝 Contributing
 
+**Requesting a feature or fix:** open an issue using the **Factory requirement**
+template (`New issue` → "Factory requirement"). Describe the problem and
+desired outcome, not the solution — this repo runs the
+[Claude Software Factory](https://github.com/genai-jerry/claude-software-factory)
+pipeline, which turns the issue into a spec, plan, implementation, and PR
+through a series of approval gates.
+
+**Contributing code directly:**
+
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add amazing feature'`)
@@ -596,7 +605,7 @@ docker-compose restart postgres
 
 ### Getting Help
 
-- GitHub Issues: Report bugs and request features
+- GitHub Issues: Report bugs, or request features via the "Factory requirement" issue template
 - Documentation: Check `/docs` folder for detailed guides
 - Logs: Always check application logs first
 


### PR DESCRIPTION
The factory-requirement issue template and factory-*.yml workflows shipped without any mention in the repo's own docs: CLAUDE.md's CI/CD section still described nonexistent ci.yml/cd.yml/deploy.yml files, and README's Contributing/Getting Help sections only described the manual fork+PR flow. Point both at the issue template as the intake entry point for the agent pipeline.