### PR TITLE
Listen for issues.closed so merged tasks release their dependents

### DIFF
--- a/.github/workflows/factory-pipeline.yml
+++ b/.github/workflows/factory-pipeline.yml
@@ -5,7 +5,7 @@ name: Factory pipeline
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, closed]
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
One line in the caller stub: add `closed` to `issues.types`.

## Why

The dispatcher runs once, when the epic reaches `factory:design-approved`, and marks only the tasks with no dependencies `factory:ready`. Everything else is left deliberately unlabelled. Nothing watched for the event that frees them — their blocker merging.

So when #24 merged and closed #20, the tasks it unblocked (#21, #22) stayed with **no `factory:*` label at all**. Nothing about that state says "waiting", and commenting `Approved` on them could not work either, because `Approved` starts an implementer from `factory:ready` and they had never got there. Epic #17 looked finished when three of its four tasks hadn't started.

`claude-software-factory@v1` now re-dispatches a task's parent epic when that task closes — guarded to epics still in `factory:design-approved`, and idempotent because the dispatcher skips tasks that already carry a state label. But the event has to reach the router, and this stub owns the triggers.

## Effect

| Before | After |
|---|---|
| Task PR merges → dependents sit unlabelled until someone re-runs dispatch by hand | Task PR merges → epic re-dispatched → newly unblocked tasks get `factory:ready` |

From there `Approved` on the task starts its implementer, as it does today.

## Scope

Both refs still pin `v1` — no version bump, no other change. Non-task issues closing, unparseable task titles, an unreachable parent epic and reopen events are all inert on the router side, so the extra trigger only produces a run when a genuine factory task closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbjYcaX3CkwRzKregzEF5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbjYcaX3CkwRzKregzEF5G)_