### PR TITLE
Add project attribution and Software Factory documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,8 @@ Once running, access interactive API documentation:
 
 ## 👤 About This Project
 
-Built by [Jerry Kurian](https://github.com/genai-jerry) at
+Built by [Jerry Kurian](https://www.linkedin.com/in/jerryk/)
+([@genai-jerry](https://github.com/genai-jerry)) at
 [GenAI People](https://genaipeople.com).
 
 The app above is one half of what this repository is for. The other half is a

--- a/README.md
+++ b/README.md
@@ -549,6 +549,21 @@ Once running, access interactive API documentation:
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
+## 👤 About This Project
+
+Built by [Jerry Kurian](https://github.com/genai-jerry) at
+[GenAI People](https://genaipeople.com).
+
+The app above is one half of what this repository is for. The other half is a
+question about process: how much of a full-stack build can be handed to AI agents
+without giving up review, traceability or control of `main`. So the repo is itself
+managed by the [Software Factory](https://github.com/genai-jerry/claude-software-factory)
+— GitHub issues carry pipeline state, OpenSpec carries the specs, and every change
+clears three human approval gates before it can merge.
+
+If that is the part you came for, `.factory/profile.json` and `openspec/` are
+where the machinery is visible on a real codebase rather than a toy one.
+
 ## 📝 License
 
 This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
Added an "About This Project" section to the README documenting the project's creator and highlighting the unique aspect of this repository: it serves as both a functional insurance agent application and a real-world demonstration of AI-assisted full-stack development with human oversight and control.

## Changes
- Added new "👤 About This Project" section in README.md between Contributing and License sections
- Documents Jerry Kurian as the project creator with LinkedIn and GitHub links
- Explains the dual purpose of the repository: the application itself and the process/methodology
- References the Software Factory framework used to manage the repository
- Points readers to `.factory/profile.json` and `openspec/` directories for visibility into the AI-assisted development pipeline on a production codebase

## Details
This addition serves as project documentation and attribution while also educating users about the repository's unique approach to AI-assisted development with human approval gates, GitHub issue-based pipeline state, and OpenSpec specifications. The section is positioned logically in the README flow and maintains consistency with the existing documentation style.

https://claude.ai/code/session_01SMbkwXQEvATsMqhLymENLh