### PR TITLE
Update factory pipeline ref to milestone-issues-stuck branch

### DIFF
--- a/.github/workflows/factory-pipeline.yml
+++ b/.github/workflows/factory-pipeline.yml
@@ -3,7 +3,7 @@ name: Factory pipeline
 # Caller stub. All logic lives in the factory repo; this file owns only the
 # triggers and the version pin. Bump both refs together when upgrading.
 #
-# CANARY PIN: both refs point at the factory's release-gating branch rather
+# CANARY PIN: both refs point at the factory's release-gating fix branch rather
 # than v1, because release gating (FACTORY.md §2d) is not on v1 yet and the
 # config in .github/factory-release.json does nothing without it. This repo is
 # the canary for that change. Once the factory PR is merged and v1 is
@@ -41,9 +41,9 @@ permissions:
 
 jobs:
   factory:
-    uses: genai-jerry/claude-software-factory/.github/workflows/factory-pipeline.yml@claude/milestone-gated-issues-ib3evl
+    uses: genai-jerry/claude-software-factory/.github/workflows/factory-pipeline.yml@claude/milestone-issues-stuck-ivwp6p
     secrets: inherit
     with:
       role: ${{ inputs.role }}
       issue_number: ${{ inputs.issue_number }}
-      factory_ref: claude/milestone-gated-issues-ib3evl
+      factory_ref: claude/milestone-issues-stuck-ivwp6p


### PR DESCRIPTION
## Summary
Updates the GitHub Actions factory pipeline workflow to use a new factory branch reference that addresses stuck milestone-based issues.

## Changes
- Updated factory workflow `uses` reference from `claude/milestone-gated-issues-ib3evl` to `claude/milestone-issues-stuck-ivwp6p`
- Updated `factory_ref` input parameter to match the new branch reference
- Updated canary pin comment to clarify this is the "release-gating fix branch"

## Details
This change pins the factory pipeline to a different branch in the `genai-jerry/claude-software-factory` repository. The new branch (`claude/milestone-issues-stuck-ivwp6p`) appears to address issues with milestone-based processing that were present in the previous reference. Both the workflow reference and the factory_ref parameter are kept in sync as required by the canary pin convention documented in the workflow comments.

https://claude.ai/code/session_01BYGTfKs1zgikrScA2VNYR7