### PR TITLE
chore(factory): move the pipeline stub back to v1

### DIFF
--- a/.github/workflows/factory-pipeline.yml
+++ b/.github/workflows/factory-pipeline.yml
@@ -3,11 +3,9 @@ name: Factory pipeline
 # Caller stub. All logic lives in the factory repo; this file owns only the
 # triggers and the version pin. Bump both refs together when upgrading.
 #
-# CANARY PIN: both refs point at the factory's release-gating fix branch rather
-# than v1, because release gating (FACTORY.md §2d) is not on v1 yet and the
-# config in .github/factory-release.json does nothing without it. This repo is
-# the canary for that change. Once the factory PR is merged and v1 is
-# fast-forwarded, set both refs back to `v1`.
+# Back on `v1`: release gating (FACTORY.md §2d) and the fix for a gated release
+# going silent are both released there now, so the canary pin this repo carried
+# while that change was in flight is no longer needed.
 
 on:
   issues:
@@ -41,9 +39,9 @@ permissions:
 
 jobs:
   factory:
-    uses: genai-jerry/claude-software-factory/.github/workflows/factory-pipeline.yml@claude/milestone-issues-stuck-ivwp6p
+    uses: genai-jerry/claude-software-factory/.github/workflows/factory-pipeline.yml@v1
     secrets: inherit
     with:
       role: ${{ inputs.role }}
       issue_number: ${{ inputs.issue_number }}
-      factory_ref: claude/milestone-issues-stuck-ivwp6p
+      factory_ref: v1


### PR DESCRIPTION
v1 has been fast-forwarded to the factory's main (63ea1e5), so it now carries both release gating and the fix for a gated release going silent. The canary pin this repo held while that change was in flight can go, putting all three stubs (pipeline, test, branch guard) back on the same released ref.


Claude-Session: https://claude.ai/code/session_01BYGTfKs1zgikrScA2VNYR7